### PR TITLE
Bump slack conversation find limit

### DIFF
--- a/packages/cdk-codepipeline-slack-lambda/src/interactions/slack-bot.ts
+++ b/packages/cdk-codepipeline-slack-lambda/src/interactions/slack-bot.ts
@@ -40,7 +40,7 @@ export class SlackBot {
     }
 
     public async findChannel(name) {
-        const response = await this.bot.conversations.list();
+        const response = await this.bot.conversations.list({ limit: 1000 });
         return response.channels.find(channel => channel.name === name);
     }
 


### PR DESCRIPTION
First: Thank you for sharing this code, it's a great time saver!

We've got a lot of Slack channels, so `SlackBot` isn't finding our configured channel name in the first page.

This is a quick fix to bump the size of page that `conversations.list()` will return, there doesn't appear to be an endpoint to return just a single channel by name.

Would you consider removing the name mapping, and require the slack ID directly in the config to save the API lookup altogether?