### PR TITLE
Add slackChannelId to SlackApprovalAction

### DIFF
--- a/packages/cdk-codepipeline-slack-lambda/src/interactions/approval-interactions.ts
+++ b/packages/cdk-codepipeline-slack-lambda/src/interactions/approval-interactions.ts
@@ -16,8 +16,8 @@ const pipeline = new CodePipeline();
 
 const bot = new SlackBot({
     token: SLACK_BOT_TOKEN,
-    channel: SLACK_CHANNEL,
-    channel_id: SLACK_CHANNEL_ID,
+    channelName: SLACK_CHANNEL,
+    channelId: SLACK_CHANNEL_ID,
     name: SLACK_BOT_NAME,
     icon: SLACK_BOT_ICON,
 });

--- a/packages/cdk-codepipeline-slack-lambda/src/interactions/approval-interactions.ts
+++ b/packages/cdk-codepipeline-slack-lambda/src/interactions/approval-interactions.ts
@@ -7,6 +7,7 @@ import { ApprovalMessageBuilder } from './approval_message_builder';
 const {
     SLACK_BOT_TOKEN,
     SLACK_CHANNEL,
+    SLACK_CHANNEL_ID,
     SLACK_BOT_NAME,
     SLACK_BOT_ICON,
 } = process.env;
@@ -16,6 +17,7 @@ const pipeline = new CodePipeline();
 const bot = new SlackBot({
     token: SLACK_BOT_TOKEN,
     channel: SLACK_CHANNEL,
+    channel_id: SLACK_CHANNEL_ID,
     name: SLACK_BOT_NAME,
     icon: SLACK_BOT_ICON,
 });

--- a/packages/cdk-codepipeline-slack/README.md
+++ b/packages/cdk-codepipeline-slack/README.md
@@ -33,15 +33,15 @@ export class CodepipelineSlackApprovalStack extends Stack {
     });
 
     const sourceArtifact = new Artifact();
-    
+
     const sourceAction = new CodeCommitSourceAction({
       actionName: 'CodeCommit',
       repository,
       output: sourceArtifact
     });
-    
+
     const project = new PipelineProject(this, 'MyProject');
-    
+
     const buildAction = new CodeBuildAction({
       actionName: 'CodeBuild',
       project,
@@ -50,13 +50,13 @@ export class CodepipelineSlackApprovalStack extends Stack {
 
     const slackBotToken = process.env.SLACK_BOT_TOKEN as string;
     const slackSigningSecret = process.env.SLACK_SIGNING_SECRET as string;
-    const slackChannel = process.env.SLACK_CHANNEL as string;
+    const slackChannelId = process.env.SLACK_CHANNEL_ID as string;
 
     const approvalAction = new SlackApprovalAction({
       actionName: 'SlackApproval',
       slackBotToken,
       slackSigningSecret,
-      slackChannel,
+      slackChannelId,
       externalEntityLink: 'http://cloudcomponents.org',
       additionalInformation:
         'Would you like to promote the build to production?'

--- a/packages/cdk-codepipeline-slack/src/slack-approval-action.ts
+++ b/packages/cdk-codepipeline-slack/src/slack-approval-action.ts
@@ -17,7 +17,8 @@ import { PolicyStatement } from '@aws-cdk/aws-iam';
 export interface SlackApprovalActionProps extends CommonActionProps {
     slackBotToken: string;
     slackSigningSecret: string;
-    slackChannel: string;
+    slackChannel?: string;
+    slackChannelId?: string;
     slackBotName?: string;
     slackBotIcon?: string;
     additionalInformation?: string;
@@ -49,7 +50,8 @@ export class SlackApprovalAction extends Action {
         const environment = {
             SLACK_BOT_TOKEN: this.props.slackBotToken,
             SLACK_SIGNING_SECRET: this.props.slackSigningSecret,
-            SLACK_CHANNEL: this.props.slackChannel,
+            SLACK_CHANNEL: this.props.slackChannel as string,
+            SLACK_CHANNEL_ID: this.props.slackChannelId as string,
             SLACK_BOT_NAME: this.props.slackBotName || 'buildbot',
             SLACK_BOT_ICON: this.props.slackBotIcon || ':robot_face:',
         };


### PR DESCRIPTION
This removes the need to lookup channel ids by name.

`slackChannel` (name) is still present, just marked as optional.